### PR TITLE
Fix buggy matching in `get_black_args`

### DIFF
--- a/cblack/utils/proc.py
+++ b/cblack/utils/proc.py
@@ -32,7 +32,8 @@ def execute(
 def get_black_args() -> Dict[str, Set[str]]:
     cmd = ["black", "--help"]
     args = {}
-    regex = re.compile(r"^\s*--?[^\s,](?:\s*,\s*--?[^\s,]+)*")
+    arg_match = r"--?[a-zA-Z0-9_-]+"
+    regex = re.compile(f"^\s+{arg_match}(?:,\s{arg_match})?")
     try:
         for line, _ in execute(cmd):
             if isinstance(line, bytes):


### PR DESCRIPTION
Fixes #1.

The `--no-color` and `--safe` flags still won't work with this PR, but I figure that this is a simple incremental improvement worth merging.

Warning: I am not sure how to test whether everything "downstream" works properly.  I have only tested that `utils.proc.get_black_args()` returns something that looks reasonable (in contrast to what it [returned previously](https://github.com/tchar/configparser-black/issues/1#issuecomment-1429980825)):
```
In [1]: import proc

In [2]: proc.get_black_args()
Out[2]:
{'-c': {'--code', '-c'},
 '--code': {'--code', '-c'},
 '-l': {'--line-length', '-l'},
 '--line-length': {'--line-length', '-l'},
 '-t': {'--target-version', '-t'},
 '--target-version': {'--target-version', '-t'},
 '--pyi': {'--pyi'},
 '--ipynb': {'--ipynb'},
 '--python-cell-magics': {'--python-cell-magics'},
 '-x': {'--skip-source-first-line', '-x'},
 '--skip-source-first-line': {'--skip-source-first-line', '-x'},
 '-S': {'--skip-string-normalization', '-S'},
 '--skip-string-normalization': {'--skip-string-normalization', '-S'},
 '-C': {'--skip-magic-trailing-comma', '-C'},
 '--skip-magic-trailing-comma': {'--skip-magic-trailing-comma', '-C'},
 '--preview': {'--preview'},
 '--check': {'--check'},
 '--diff': {'--diff'},
 '--color': {'--color'},
 '--fast': {'--fast'},
 '--required-version': {'--required-version'},
 '--include': {'--include'},
 '--exclude': {'--exclude'},
 '--extend-exclude': {'--extend-exclude'},
 '--force-exclude': {'--force-exclude'},
 '--stdin-filename': {'--stdin-filename'},
 '-W': {'--workers', '-W'},
 '--workers': {'--workers', '-W'},
 '-q': {'--quiet', '-q'},
 '--quiet': {'--quiet', '-q'},
 '-v': {'--verbose', '-v'},
 '--verbose': {'--verbose', '-v'},
 '--version': {'--version'},
 '--config': {'--config'},
 '-h': {'--help', '-h'},
 '--help': {'--help', '-h'}}
```